### PR TITLE
Fixed fzf not popping up bug by cleaning up macrosInProgress

### DIFF
--- a/autoload/macrobatics.vim
+++ b/autoload/macrobatics.vim
@@ -648,6 +648,7 @@ function! macrobatics#play(reg, cnt)
     " Don't need to use i here though, because we only want this to run at the very end
     " Since otherwise it will overwrite s:repeatMacro
     call feedkeys("\<plug>(Mac__OnPlayMacroCompleted)", 'm')
+    let s:macrosInProgress -= 1
 endfunction
 
 function! s:assert(value, ...)


### PR DESCRIPTION
Hey Steve,

I just got some time to look at the code and debug it. This will fix FZF not popping up again after failed macros. s:macrosInProgress just needs to be cleaned up.